### PR TITLE
fix: correct typo in metadata variable name in file.py

### DIFF
--- a/src/spaceone/file_manager/interface/rest/file.py
+++ b/src/spaceone/file_manager/interface/rest/file.py
@@ -40,7 +40,7 @@ class Files(BaseAPI):
             "resource_group": "SYSTEM",
         }
 
-        file_svc = FileService(metdata)
+        file_svc = FileService(metadata)
         response: dict = file_svc.add(params)
         
         download_url = self.get_download_url(response)


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
 fix: correct typo in metadata variable name in file.py
### Known issue