### PR TITLE
fix: update proxy_pass to use 127.0.0.1 instead of localhost

### DIFF
--- a/deploy/helm/config/proxy.conf
+++ b/deploy/helm/config/proxy.conf
@@ -5,7 +5,7 @@ server {
   error_log  /var/log/nginx/spaceone-error.log warn;
 
   location / {
-    proxy_pass http://localhost:8000/;
+    proxy_pass http://127.0.0.1:8000/;
 
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [x] etc

### Description 
 [fix: update proxy_pass to use 127.0.0.1 instead of localhost](https://github.com/cloudforet-io/file-manager/commit/b5a419b7140174b7ef7411050c3f6a96344854f9)
### Known issue