### PR TITLE
feat: remove resource_group from file parameters in add and download functions

### DIFF
--- a/src/spaceone/file_manager/interface/rest/file.py
+++ b/src/spaceone/file_manager/interface/rest/file.py
@@ -159,10 +159,13 @@ class Files(BaseAPI):
         
         try:
 
+            resource_group = params["resource_group"]
+            del params["resource_group"]
+
             file_svc = FileService(metadata)
             file_info: dict = file_svc.add(params)
 
-            resource_group = file_info["resource_group"]
+            # resource_group = file_info["resource_group"]
             file_id = file_info["file_id"]
 
             file_conn_mgr = FileConnectorManager()
@@ -176,10 +179,13 @@ class Files(BaseAPI):
 
     async def download_file(self, metadata, params) -> StreamingResponse:
 
+        resource_group = params["resource_group"]
+        del params["resource_group"]
+
         file_svc = FileService(metadata)
         file_info: dict = file_svc.get(params)
         
-        resource_group = file_info["resource_group"]
+        # resource_group = file_info["resource_group"]
         file_id = file_info["file_id"]
 
         try:


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
feat: remove resource_group from file parameters in add and download functions
### Known issue